### PR TITLE
refactor: store filesystems outside of the synchro, in typed lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "log",
  "serde",
  "tarpc",
+ "thiserror 2.0.3",
  "tokio",
  "uuid",
 ]

--- a/crates/brume-cli/src/main.rs
+++ b/crates/brume-cli/src/main.rs
@@ -41,16 +41,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match cli.command {
         Commands::New { local, remote } => {
-            let local_desc = AnyFsDescription::from(&local);
-            let remote_desc = AnyFsDescription::from(&remote);
+            let local_desc = AnyFsDescription::from(local.clone());
+            let remote_desc = AnyFsDescription::from(remote.clone());
+
             println!("Creating synchro between {local_desc} and {remote_desc}");
-            let res = connect_to_daemon()
+            connect_to_daemon()
                 .await
                 .map_err(|_| "Failed to connect to brume daemon. Are your sure it's running ?")?
                 .new_synchro(context::current(), local, remote)
                 .await??;
 
-            println!("Done: {}", res.id());
+            println!("Done");
         }
     }
 
@@ -81,8 +82,6 @@ fn parse_fs_argument(arg: &str) -> Result<AnyFsCreationInfo, String> {
             &path,
         )))
     } else {
-        Err(format!(
-            "{arg} is neither a valid path on your filesystem nor an url"
-        ))
+        Err("<FILESYSTEM> should be a valid path on your filesystem or an url".to_string())
     }
 }

--- a/crates/brume-daemon/Cargo.toml
+++ b/crates/brume-daemon/Cargo.toml
@@ -14,6 +14,7 @@ futures = { version = "0.3", optional = true }
 log = { version = "0.4", optional = true }
 env_logger = { version = "0.11", optional = true }
 anyhow = { version = "1.0", optional = true }
+thiserror = { version = "2.0", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 interprocess = { version = "2.2", features = ["tokio"], optional = true }
 
@@ -26,6 +27,7 @@ server = [
 	"dep:log",
 	"dep:env_logger",
 	"dep:anyhow",
+	"dep:thiserror",
 	"dep:tokio",
 	"dep:interprocess",
 	"dep:brume",

--- a/crates/brume-daemon/src/daemon.rs
+++ b/crates/brume-daemon/src/daemon.rs
@@ -4,71 +4,21 @@ use log::{info, warn};
 use tarpc::context::Context;
 use tokio::sync::mpsc::UnboundedSender;
 
-use brume::{
-    concrete::{local::LocalDir, nextcloud::NextcloudFs, ConcreteFS},
-    synchro::{Synchro, Synchronizable},
-    Error,
-};
-
 use crate::{
-    protocol::{AnyFsCreationInfo, AnyFsDescription, BrumeService, SynchroId},
-    server::ReadOnlySynchroList,
+    protocol::{AnyFsCreationInfo, AnyFsDescription, BrumeService},
+    synchro_list::ReadOnlySynchroList,
 };
-
-/// Represent [`Synchro`] object where both concrete Filesystem types are only known at runtime.
-// TODO: create using a macro ?
-pub enum AnySynchro {
-    LocalNextcloud(Synchro<LocalDir, NextcloudFs>),
-    NextcloudLocal(Synchro<NextcloudFs, LocalDir>),
-    LocalLocal(Synchro<LocalDir, LocalDir>),
-    NextcloudNextcloud(Synchro<NextcloudFs, NextcloudFs>),
-}
-
-impl AnySynchro {
-    fn description(&self) -> (AnyFsDescription, AnyFsDescription) {
-        match self {
-            AnySynchro::LocalNextcloud(synchro) => (
-                AnyFsDescription::LocalDir(synchro.local().concrete().description()),
-                AnyFsDescription::Nextcloud(synchro.remote().concrete().description()),
-            ),
-            AnySynchro::NextcloudLocal(synchro) => (
-                AnyFsDescription::Nextcloud(synchro.local().concrete().description()),
-                AnyFsDescription::LocalDir(synchro.remote().concrete().description()),
-            ),
-            AnySynchro::LocalLocal(synchro) => (
-                AnyFsDescription::LocalDir(synchro.local().concrete().description()),
-                AnyFsDescription::LocalDir(synchro.remote().concrete().description()),
-            ),
-
-            AnySynchro::NextcloudNextcloud(synchro) => (
-                AnyFsDescription::Nextcloud(synchro.local().concrete().description()),
-                AnyFsDescription::Nextcloud(synchro.remote().concrete().description()),
-            ),
-        }
-    }
-}
-
-impl Synchronizable for AnySynchro {
-    async fn full_sync(&mut self) -> Result<(), Error> {
-        match self {
-            AnySynchro::LocalNextcloud(inner) => inner.full_sync().await,
-            AnySynchro::NextcloudLocal(inner) => inner.full_sync().await,
-            AnySynchro::LocalLocal(inner) => inner.full_sync().await,
-            AnySynchro::NextcloudNextcloud(inner) => inner.full_sync().await,
-        }
-    }
-}
 
 /// The daemon holds the list of the synchronized folders, and can be queried by client applications
 #[derive(Clone)]
 pub struct BrumeDaemon {
-    to_server: UnboundedSender<(SynchroId, AnySynchro)>,
+    to_server: UnboundedSender<(AnyFsCreationInfo, AnyFsCreationInfo)>,
     synchro_list: ReadOnlySynchroList,
 }
 
 impl BrumeDaemon {
     pub(crate) fn new(
-        to_server: UnboundedSender<(SynchroId, AnySynchro)>,
+        to_server: UnboundedSender<(AnyFsCreationInfo, AnyFsCreationInfo)>,
         synchro_list: ReadOnlySynchroList,
     ) -> Self {
         Self {
@@ -84,64 +34,25 @@ impl BrumeService for BrumeDaemon {
         _context: Context,
         local: AnyFsCreationInfo,
         remote: AnyFsCreationInfo,
-    ) -> Result<SynchroId, String> {
-        let local_desc = AnyFsDescription::from(&local);
-        let remote_desc = AnyFsDescription::from(&remote);
+    ) -> Result<(), String> {
+        let local_desc = AnyFsDescription::from(local.clone());
+        let remote_desc = AnyFsDescription::from(remote.clone());
         info!("Received synchro creation request: local {local_desc}, remote {remote_desc}");
-        let sync = match (local, remote) {
-            (AnyFsCreationInfo::LocalDir(local_path), AnyFsCreationInfo::LocalDir(remote_path)) => {
-                let local = LocalDir::try_from(local_path).map_err(|e| e.to_string())?;
-                let remote = LocalDir::try_from(remote_path).map_err(|e| e.to_string())?;
 
-                AnySynchro::LocalLocal(Synchro::new(local, remote))
-            }
-            (AnyFsCreationInfo::LocalDir(local_path), AnyFsCreationInfo::Nextcloud(remote_log)) => {
-                let local = LocalDir::try_from(local_path).map_err(|e| e.to_string())?;
-                let remote = NextcloudFs::try_from(remote_log).map_err(|e| e.to_string())?;
-
-                AnySynchro::LocalNextcloud(Synchro::new(local, remote))
-            }
-            (AnyFsCreationInfo::Nextcloud(local_log), AnyFsCreationInfo::LocalDir(remote_path)) => {
-                let local = NextcloudFs::try_from(local_log).map_err(|e| e.to_string())?;
-                let remote = LocalDir::try_from(remote_path).map_err(|e| e.to_string())?;
-
-                AnySynchro::NextcloudLocal(Synchro::new(local, remote))
-            }
-            (AnyFsCreationInfo::Nextcloud(local_log), AnyFsCreationInfo::Nextcloud(remote_log)) => {
-                let local = NextcloudFs::try_from(local_log).map_err(|e| e.to_string())?;
-
-                let remote = NextcloudFs::try_from(remote_log).map_err(|e| e.to_string())?;
-
-                AnySynchro::NextcloudNextcloud(Synchro::new(local, remote))
-            }
-        };
-
+        // Check if the fs pair is already in sync to return an error to the user
         {
             let list = self.synchro_list.read().await;
 
-            // TODO: also do before insertion to avoir race with elems in queue
-            for sync in list.values() {
-                let sync = sync.lock().await;
-                let (cur_local_desc, cur_remote_desc) = sync.description();
-                println!("cur: {cur_local_desc}, {cur_remote_desc}");
-                println!("adding: {local_desc}, {remote_desc}");
-                if (cur_local_desc == local_desc || cur_local_desc == cur_remote_desc)
-                    && (cur_remote_desc == local_desc || cur_remote_desc == remote_desc)
-                {
-                    warn!("Duplicate sync request, skipping");
-                    return Err("Filesystems are already in sync".to_string());
-                }
+            if list.is_synchronized(&local_desc, &remote_desc) {
+                warn!("Duplicate sync request, skipping");
+                return Err("Filesystems are already in sync".to_string());
             }
         }
 
-        let syncid = SynchroId::new();
-
         self.to_server
-            .send((syncid, sync))
+            .send((local, remote))
             .map_err(|e| e.to_string())?;
 
-        info!("Synchro created with id {}", syncid.id());
-
-        Ok(syncid)
+        Ok(())
     }
 }

--- a/crates/brume-daemon/src/lib.rs
+++ b/crates/brume-daemon/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod protocol;
+pub mod synchro_list;
 
 #[cfg(feature = "server")]
 pub mod daemon;

--- a/crates/brume-daemon/src/protocol.rs
+++ b/crates/brume-daemon/src/protocol.rs
@@ -32,15 +32,17 @@ impl SynchroId {
     }
 }
 
-/// The information needed to create a FS that can be synchronized, remote or local
+/// The information needed to create a FS that can be synchronized.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AnyFsCreationInfo {
     LocalDir(<LocalDir as ConcreteFS>::CreationInfo),
     Nextcloud(<NextcloudFs as ConcreteFS>::CreationInfo),
 }
 
-/// The information needed to describe a FS that can be synchronized, remote or local
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
+/// The information needed to describe a FS that can be synchronized.
+///
+/// This is used for display and to avoid duplicate synchros.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum AnyFsDescription {
     LocalDir(<LocalDir as ConcreteFS>::Description),
     Nextcloud(<NextcloudFs as ConcreteFS>::Description),
@@ -55,8 +57,8 @@ impl Display for AnyFsDescription {
     }
 }
 
-impl From<&AnyFsCreationInfo> for AnyFsDescription {
-    fn from(value: &AnyFsCreationInfo) -> Self {
+impl From<AnyFsCreationInfo> for AnyFsDescription {
+    fn from(value: AnyFsCreationInfo) -> Self {
         match value {
             AnyFsCreationInfo::LocalDir(dir) => Self::LocalDir(dir.into()),
             AnyFsCreationInfo::Nextcloud(nextcloud) => Self::Nextcloud(nextcloud.into()),
@@ -67,8 +69,6 @@ impl From<&AnyFsCreationInfo> for AnyFsDescription {
 #[tarpc::service]
 pub trait BrumeService {
     /// Create a new synchronization between a "remote" and a "local" fs
-    async fn new_synchro(
-        local: AnyFsCreationInfo,
-        remote: AnyFsCreationInfo,
-    ) -> Result<SynchroId, String>;
+    async fn new_synchro(local: AnyFsCreationInfo, remote: AnyFsCreationInfo)
+        -> Result<(), String>;
 }

--- a/crates/brume-daemon/src/synchro_list.rs
+++ b/crates/brume-daemon/src/synchro_list.rs
@@ -1,0 +1,322 @@
+use std::{any::Any, collections::HashMap, fmt::Display, sync::Arc};
+
+use brume::{
+    concrete::{
+        local::{LocalDir, LocalDirDescription},
+        nextcloud::{NextcloudFs, NextcloudFsDescription},
+        ConcreteFS, ConcreteFsError,
+    },
+    filesystem::FileSystem,
+    synchro::Synchro,
+};
+use futures::future::join_all;
+use thiserror::Error;
+use tokio::sync::{Mutex, RwLock, RwLockReadGuard};
+
+use crate::protocol::{AnyFsCreationInfo, AnyFsDescription, SynchroId};
+
+#[derive(Error, Debug)]
+pub enum SyncError {
+    #[error("Error during sync process")]
+    SyncFailed(#[from] SynchroFailed),
+    #[error("Invalid synchro")]
+    InvalidSynchroState(#[from] InvalidSynchro),
+}
+
+#[derive(Error, Debug)]
+#[error("Failed to synchronize {synchro}")]
+pub struct SynchroFailed {
+    synchro: AnySynchroRef,
+    source: brume::Error,
+}
+
+#[derive(Error, Debug)]
+#[error("Synchro in invalid state: {synchro}")]
+pub struct InvalidSynchro {
+    synchro: AnySynchroRef,
+}
+
+impl From<AnySynchroRef> for InvalidSynchro {
+    fn from(value: AnySynchroRef) -> Self {
+        InvalidSynchro { synchro: value }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum SynchroCreationError {
+    #[error("The filesystems are already synchronized")]
+    AlreadyPresent,
+    #[error("Failed to instantiate filesystem object")]
+    FileSystemCreationError(#[from] ConcreteFsError),
+}
+
+/// A [`Synchro`] where the [`Concrete`] filesystems are only known at runtime.
+///
+/// This type represents only an index and needs a valid [`SynchroList`], to actually be used. It
+/// must not be used after the Synchro it points to has been removed from the SynchroList.
+///
+/// [`Concrete`]: ConcreteFS
+#[derive(Clone, Debug)]
+pub struct AnySynchroRef {
+    local: AnyFsDescription,
+    remote: AnyFsDescription,
+    _id: SynchroId,
+}
+
+impl Display for AnySynchroRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "synchro between {} and {}", self.local, self.remote)
+    }
+}
+
+/// A [`SynchroList`] that allows only read-only access.
+///
+/// The list content cannot be modified, but since the underlying [`FileSystems`] are locked behind
+/// mutexes, they are themselves modifiabled.
+///
+/// [`FileSystems`]: FileSystem
+#[derive(Clone)]
+pub struct ReadOnlySynchroList {
+    maps: Arc<RwLock<SynchroList>>,
+}
+
+impl ReadOnlySynchroList {
+    pub async fn read(&self) -> RwLockReadGuard<SynchroList> {
+        self.maps.read().await
+    }
+}
+
+/// A synchronized Filesystem pair where both filesystems are in a Mutex
+struct SynchroMutex<
+    'local,
+    'remote,
+    LocalConcrete: ConcreteFS + 'static,
+    RemoteConcrete: ConcreteFS + 'static,
+> {
+    local: &'local Mutex<FileSystem<LocalConcrete>>,
+    remote: &'remote Mutex<FileSystem<RemoteConcrete>>,
+}
+
+/// Allow to easily convert the given type into [`Any`] for runtime downcast
+trait DynTyped {
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T: ConcreteFS + 'static> DynTyped for Mutex<FileSystem<T>> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Holds a list of pair of [`FileSystems`] that can be synchronized using [`Synchro::full_sync`].
+///
+/// The filesystems can be any of the [`supported types`]
+///
+/// [`FileSystems`]: FileSystem
+/// [`supported types`]: crate::protocol::AnyFsCreationInfo
+#[derive(Default)]
+pub struct SynchroList {
+    synchros: Vec<AnySynchroRef>,
+    nextcloud_list: HashMap<NextcloudFsDescription, Mutex<FileSystem<NextcloudFs>>>,
+    local_dir_list: HashMap<LocalDirDescription, Mutex<FileSystem<LocalDir>>>,
+}
+
+impl SynchroList {
+    /// Create a new empty list
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn create_and_insert_fs(&mut self, fs_info: AnyFsCreationInfo) -> Result<(), ConcreteFsError> {
+        match fs_info {
+            AnyFsCreationInfo::LocalDir(info) => {
+                let creation_info = info.clone().try_into()?;
+                self.local_dir_list
+                    .entry(info.into())
+                    .or_insert_with(|| Mutex::new(FileSystem::new(creation_info)));
+                Ok(())
+            }
+            AnyFsCreationInfo::Nextcloud(info) => {
+                let creation_info = info.clone().try_into()?;
+                self.nextcloud_list
+                    .entry(info.into())
+                    .or_insert_with(|| Mutex::new(FileSystem::new(creation_info)));
+                Ok(())
+            }
+        }
+    }
+
+    /// Check if the two Filesystems in the pair are already synchronized together.
+    pub fn is_synchronized(
+        &self,
+        local_desc: &AnyFsDescription,
+        remote_desc: &AnyFsDescription,
+    ) -> bool {
+        for sync in &self.synchros {
+            if (&sync.local == local_desc || &sync.local == remote_desc)
+                && (&sync.remote == local_desc || &sync.remote == remote_desc)
+            {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Create and insert a new filesystem Synchro in the list
+    pub fn insert(
+        &mut self,
+        local: AnyFsCreationInfo,
+        remote: AnyFsCreationInfo,
+    ) -> Result<(), SynchroCreationError> {
+        let local_desc = local.clone().into();
+        let remote_desc = remote.clone().into();
+
+        if self.is_synchronized(&local_desc, &remote_desc) {
+            return Err(SynchroCreationError::AlreadyPresent);
+        }
+        let id = SynchroId::new();
+
+        self.create_and_insert_fs(local.clone())?;
+        self.create_and_insert_fs(remote.clone())?;
+
+        let synchro = AnySynchroRef {
+            local: local.into(),
+            remote: remote.into(),
+            _id: id,
+        };
+
+        self.synchros.push(synchro);
+
+        Ok(())
+    }
+
+    fn get_fs<Concrete: ConcreteFS + 'static>(
+        &self,
+        desc: &AnyFsDescription,
+    ) -> Option<&Mutex<FileSystem<Concrete>>> {
+        match desc {
+            AnyFsDescription::LocalDir(desc) => self
+                .local_dir_list
+                .get(desc)
+                .and_then(|fs| fs.as_any().downcast_ref::<Mutex<FileSystem<Concrete>>>()),
+            AnyFsDescription::Nextcloud(desc) => self
+                .nextcloud_list
+                .get(desc)
+                .and_then(|fs| fs.as_any().downcast_ref::<Mutex<FileSystem<Concrete>>>()),
+        }
+    }
+
+    fn get_sync<LocalConcrete: ConcreteFS + 'static, RemoteConcrete: ConcreteFS + 'static>(
+        &self,
+        synchro: &AnySynchroRef,
+    ) -> Option<SynchroMutex<LocalConcrete, RemoteConcrete>> {
+        let local = self.get_fs::<LocalConcrete>(&synchro.local)?;
+        let remote = self.get_fs::<RemoteConcrete>(&synchro.remote)?;
+
+        Some(SynchroMutex { local, remote })
+    }
+
+    /// Perfom a [`full_sync`] on the provided synchro, that should be in the list
+    ///
+    /// [`full_sync`]: brume::synchro::Synchro::full_sync
+    pub async fn sync_one<
+        LocalConcrete: ConcreteFS + 'static,
+        RemoteConcrete: ConcreteFS + 'static,
+    >(
+        &self,
+        synchro: &AnySynchroRef,
+    ) -> Result<(), SyncError> {
+        let synchro_mutex = self
+            .get_sync::<LocalConcrete, RemoteConcrete>(synchro)
+            .ok_or_else(|| InvalidSynchro::from(synchro.clone()))?;
+
+        let mut local_fs = synchro_mutex.local.lock().await;
+        let mut remote_fs = synchro_mutex.remote.lock().await;
+        let mut sync = Synchro::new(&mut local_fs, &mut remote_fs);
+        sync.full_sync().await.map_err(|e| {
+            SynchroFailed {
+                synchro: synchro.to_owned(),
+                source: e,
+            }
+            .into()
+        })
+    }
+
+    /// Perfom a [`full_sync`] on all the synchro in the list
+    ///
+    /// [`full_sync`]: brume::synchro::Synchro::full_sync
+    pub async fn sync_all(&self) -> Vec<Result<(), SyncError>> {
+        let futures: Vec<_> = self
+            .synchros
+            .iter()
+            .map(|synchro| async {
+                match (&synchro.local, &synchro.remote) {
+                    (AnyFsDescription::LocalDir(_), AnyFsDescription::LocalDir(_)) => {
+                        self.sync_one::<LocalDir, LocalDir>(synchro).await
+                    }
+                    (AnyFsDescription::LocalDir(_), AnyFsDescription::Nextcloud(_)) => {
+                        self.sync_one::<LocalDir, NextcloudFs>(synchro).await
+                    }
+                    (AnyFsDescription::Nextcloud(_), AnyFsDescription::LocalDir(_)) => {
+                        self.sync_one::<NextcloudFs, LocalDir>(synchro).await
+                    }
+                    (AnyFsDescription::Nextcloud(_), AnyFsDescription::Nextcloud(_)) => {
+                        self.sync_one::<NextcloudFs, NextcloudFs>(synchro).await
+                    }
+                }
+            })
+            .collect();
+
+        // TODO: switch to FutureUnordered ?
+        join_all(futures).await
+    }
+}
+
+/// A [`SynchroList`] that allows read-write access and can be shared between threads.
+#[derive(Clone)]
+pub struct ReadWriteSynchroList {
+    maps: Arc<RwLock<SynchroList>>,
+}
+
+impl Default for ReadWriteSynchroList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReadWriteSynchroList {
+    pub async fn read(&self) -> RwLockReadGuard<SynchroList> {
+        self.maps.read().await
+    }
+
+    /// Insert a new synchronized pair of filesystem in the list
+    pub async fn insert(
+        &self,
+        local: AnyFsCreationInfo,
+        remote: AnyFsCreationInfo,
+    ) -> Result<(), SynchroCreationError> {
+        self.maps.write().await.insert(local, remote)
+    }
+
+    /// Force a synchro of all the filesystems in the list
+    pub async fn sync_all(&self) -> Vec<Result<(), SyncError>> {
+        let maps = self.maps.read().await;
+
+        maps.sync_all().await
+    }
+
+    /// Return a read-only view of the list
+    pub fn as_read_only(&self) -> ReadOnlySynchroList {
+        ReadOnlySynchroList {
+            maps: self.maps.clone(),
+        }
+    }
+
+    /// Create a new empty list
+    pub fn new() -> Self {
+        Self {
+            maps: Arc::new(RwLock::new(SynchroList::new())),
+        }
+    }
+}

--- a/crates/brume/src/concrete/local/mod.rs
+++ b/crates/brume/src/concrete/local/mod.rs
@@ -275,7 +275,7 @@ impl<'a> From<&'a LocalSyncInfo> for () {
 }
 
 /// Uniquely identify a path on the local filesystem
-#[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Hash, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct LocalDirDescription(PathBuf);
 
 impl Display for LocalDirDescription {
@@ -284,9 +284,9 @@ impl Display for LocalDirDescription {
     }
 }
 
-impl From<&LocalDirCreationInfo> for LocalDirDescription {
-    fn from(value: &LocalDirCreationInfo) -> Self {
-        Self(value.0.clone())
+impl From<LocalDirCreationInfo> for LocalDirDescription {
+    fn from(value: LocalDirCreationInfo) -> Self {
+        Self(value.0)
     }
 }
 

--- a/crates/brume/src/concrete/mod.rs
+++ b/crates/brume/src/concrete/mod.rs
@@ -6,6 +6,7 @@ pub mod nextcloud;
 use std::error::Error;
 use std::fmt::{Debug, Display};
 use std::future::Future;
+use std::hash::Hash;
 use std::io::{self, ErrorKind};
 
 use bytes::Bytes;
@@ -63,7 +64,9 @@ pub trait ConcreteFS:
     type CreationInfo: Debug + Clone + Serialize + for<'a> Deserialize<'a>;
     /// A unique description of a particular filesystem instance
     type Description: Display
-        + for<'a> From<&'a Self::CreationInfo>
+        + From<Self::CreationInfo>
+        + Clone
+        + Hash
         + PartialEq
         + Debug
         + Serialize

--- a/crates/brume/src/concrete/nextcloud/mod.rs
+++ b/crates/brume/src/concrete/nextcloud/mod.rs
@@ -203,7 +203,7 @@ impl<'a> From<&'a NextcloudSyncInfo> for () {
 }
 
 /// Description of a connection to a nextcloud instance
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct NextcloudFsDescription {
     server_url: String,
     name: String,
@@ -233,11 +233,11 @@ impl NextcloudFsCreationInfo {
     }
 }
 
-impl From<&NextcloudFsCreationInfo> for NextcloudFsDescription {
-    fn from(value: &NextcloudFsCreationInfo) -> Self {
+impl From<NextcloudFsCreationInfo> for NextcloudFsDescription {
+    fn from(value: NextcloudFsCreationInfo) -> Self {
         Self {
-            server_url: value.server_url.to_owned(),
-            name: value.login.to_owned(),
+            server_url: value.server_url,
+            name: value.login,
         }
     }
 }

--- a/crates/brume/src/test_utils.rs
+++ b/crates/brume/src/test_utils.rs
@@ -504,8 +504,8 @@ impl Display for InnerConcreteTestNode {
     }
 }
 
-impl From<&InnerConcreteTestNode> for String {
-    fn from(value: &InnerConcreteTestNode) -> Self {
+impl From<InnerConcreteTestNode> for String {
+    fn from(value: InnerConcreteTestNode) -> Self {
         format!("{}", value)
     }
 }


### PR DESCRIPTION
This should make extensibility easier