### PR TITLE
chore(lib): remove unneeded TODO

### DIFF
--- a/crates/brume/src/vfs/dir_tree/mod.rs
+++ b/crates/brume/src/vfs/dir_tree/mod.rs
@@ -128,7 +128,6 @@ impl<SyncInfo: TryFromBytes> TryFrom<NodeState<Vec<u8>>> for NodeState<SyncInfo>
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DirTree<Data> {
     info: DirInfo<Data>,
-    // TODO: handle having a dir and file with the same name
     children: SortedNodeList<Data>,
 }
 


### PR DESCRIPTION
A file and a dir with the exact same path cannot exist on all major OS